### PR TITLE
Return JSON for accountabilities and domains on the Role model

### DIFF
--- a/backend/flindt/role/models.py
+++ b/backend/flindt/role/models.py
@@ -18,9 +18,7 @@ class Role(FlindtBaseModel):
     """
     name = models.TextField()
     purpose = models.TextField(blank=True, default='')
-    # TODO: FEED-41: Use a JSON field to validate contents.
     accountabilities = models.TextField(blank=True, default='')  # Used to store JSON
-    # TODO: FEED-41: Use a JSON field to validate contents.
     domains = models.TextField(blank=True, default='')  # Used to store JSON
     parent = models.ForeignKey('Role', related_name='children', blank=True, null=True)
     users = models.ManyToManyField(User, blank=True)

--- a/backend/flindt/role/serializers.py
+++ b/backend/flindt/role/serializers.py
@@ -18,7 +18,7 @@ class ParentRoleSerializer(serializers.ModelSerializer):
 
     def get_accountabilities(self, obj):
         """
-        Override the getter for domains to try and convert the domains to a
+        Override the getter for accountabilities to try and convert the domains to a
         correct json format.
         """
 
@@ -67,7 +67,7 @@ class RoleSerializer(serializers.ModelSerializer):
 
     def get_accountabilities(self, obj):
         """
-        Override the getter for domains to try and convert the domains to a
+        Override the getter for accountabilities to try and convert the domains to a
         correct json format.
         """
 

--- a/backend/flindt/role/serializers.py
+++ b/backend/flindt/role/serializers.py
@@ -1,3 +1,5 @@
+import json
+
 from rest_framework import serializers
 
 from .models import Role
@@ -9,6 +11,37 @@ class ParentRoleSerializer(serializers.ModelSerializer):
     not reference itself, ParentRoleSerializer is defined. This serializer is
     in fact pretty much the same as :class:`RoleSerializer`.
     """
+    # Override the default accountabilities serializer with SerializerMethodField to override the getter.
+    accountabilities = serializers.SerializerMethodField()
+    # Override the default domains serializer with SerializerMethodField to override the getter.
+    domains = serializers.SerializerMethodField()
+
+    def get_accountabilities(self, obj):
+        """
+        Override the getter for domains to try and convert the domains to a
+        correct json format.
+        """
+
+        # Try to load the obj.accountabilities as a json. If this fails return the
+        # string.
+        try:
+            return json.loads(obj.accountabilities)
+        except ValueError:
+            return obj.accountabilities
+
+    def get_domains(self, obj):
+        """
+        Override the getter for domains to try and convert the domains to a
+        correct json format.
+        """
+
+        # Try to load the obj.domains as a json. If this fails return the
+        # string.
+        try:
+            return json.loads(obj.domains)
+        except ValueError:
+            return obj.domains
+
     class Meta:
         model = Role
         fields = (
@@ -25,6 +58,38 @@ class ParentRoleSerializer(serializers.ModelSerializer):
 
 class RoleSerializer(serializers.ModelSerializer):
     parent = ParentRoleSerializer()
+    # Override the default accountabilities serializer with
+    # SerializerMethodField to override the getter.
+    accountabilities = serializers.SerializerMethodField()
+    # Override the default domains serializer with
+    # SerializerMethodField to override the getter.
+    domains = serializers.SerializerMethodField()
+
+    def get_accountabilities(self, obj):
+        """
+        Override the getter for domains to try and convert the domains to a
+        correct json format.
+        """
+
+        # Try to load the obj.accountabilities as a json. If this fails return the
+        # string.
+        try:
+            return json.loads(obj.accountabilities)
+        except ValueError:
+            return obj.accountabilities
+
+    def get_domains(self, obj):
+        """
+        Override the getter for domains to try and convert the domains to a
+        correct json format.
+        """
+
+        # Try to load the obj.domains as a json. If this fails return the
+        # string.
+        try:
+            return json.loads(obj.domains)
+        except ValueError:
+            return obj.domains
 
     class Meta:
         model = Role

--- a/frontend/src/components/RoleModal.js
+++ b/frontend/src/components/RoleModal.js
@@ -46,12 +46,6 @@ class RoleModal extends Component {
     }
 
     let { name, purpose, accountabilities } = this.props.details.data;
-    let accountabilitiesArray;
-
-    if (accountabilities) {
-      accountabilitiesArray = accountabilities.replace(/'/g, '"');
-      accountabilitiesArray = JSON.parse(accountabilitiesArray);
-    }
 
     return (
       <div>
@@ -66,11 +60,11 @@ class RoleModal extends Component {
             <h3>Purpose</h3>
             <p>{purpose}</p>
 
-            {accountabilitiesArray && (
+            {accountabilities && (
               <div>
                 <h3>Accountabilities</h3>
                 <ul>
-                  {accountabilitiesArray.map((accountability, index) => (
+                  {accountabilities.map((accountability, index) => (
                     <li key={index}>{accountability}</li>
                   ))}
                 </ul>


### PR DESCRIPTION
In the Role serializer return the accountabilities and domains fields as a JSON