### PR TITLE
componentWillReceiveProps arguments changed from two to one and only …

### DIFF
--- a/frontend/src/pages/ReceivedFeedbackList.jsx
+++ b/frontend/src/pages/ReceivedFeedbackList.jsx
@@ -10,8 +10,8 @@ class ReceivedFeedbackList extends Component {
     this.get(this.props);
   }
 
-  componentWillReceiveProps(nextProps, oldProps) {
-    this.get(nextProps, oldProps);
+  componentWillReceiveProps(nextProps) {
+    this.get(nextProps, this.props);
   }
 
   get = (nextProps = {}, oldProps = {}) => {
@@ -120,6 +120,4 @@ ReceivedFeedbackList.propTypes = {
   loading: propTypes.bool
 };
 
-export default connect(mapStateToProps, { fetchFeedbackAsReceiver })(
-  ReceivedFeedbackList
-);
+export default connect(mapStateToProps, { fetchFeedbackAsReceiver })(ReceivedFeedbackList);


### PR DESCRIPTION
…caught it now :S

it doesn't supply the props from the instance anymore so we need to pass it in ourselves